### PR TITLE
Fix SetLocale and Implement Automatic Locale Detection.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.0",
-        "orchestra/database": "~3.4.0",
+        "orchestra/testbench": "~3.0",
+        "orchestra/database": "~3.0",
         "mockery/mockery": "^0.9.4",
         "phpunit/phpunit": "~4|~5"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.0",
+        "orchestra/testbench": "~3.4.0",
+        "orchestra/database": "~3.4.0",
         "mockery/mockery": "^0.9.4",
         "phpunit/phpunit": "~4|~5"
     },

--- a/src/Middleware/LocaleMiddleware.php
+++ b/src/Middleware/LocaleMiddleware.php
@@ -19,7 +19,7 @@ class LocaleMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $request->cookies->set('locale', Translation::getRoutePrefix());
+        $request->cookies->set('locale', Translation::detectLocale($request));
 
         return $next($request);
     }

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -397,7 +397,7 @@ class Translation implements TranslationInterface
      *
      * @param Model $translation
      */
-    protected function removeCacheTranslation(Model $translation)
+    public function removeCacheTranslation(Model $translation)
     {
         $id = $this->getTranslationCacheId($translation->locale, $translation->translation);
 

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -112,7 +112,7 @@ class Translation implements TranslationInterface
             // we won't call the getLocale method as it retrieves and sets the default
             // session locale. If it has not been provided, we'll get the
             // default locale, and set it on the current session.
-            if ($toLocale) {
+            if ($toLocale != '') {
                 $toLocale = $this->firstOrCreateLocale($toLocale);
             } else {
                 $toLocale = $this->firstOrCreateLocale($this->getLocale());
@@ -189,7 +189,7 @@ class Translation implements TranslationInterface
         if ($this->request->hasCookie('locale')) {
             return $this->request->cookie('locale');
         } else {
-            return $this->getConfigDefaultLocale();
+            return $this->locale;
         }
     }
 

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -635,4 +635,24 @@ class Translation implements TranslationInterface
 
         return true;
     }
+
+    /**
+     * Detects the Default Locale Based on
+     */
+
+    public function detectLocale($request){
+        if (!$request->hasCookie('locale')) {
+            $locale = substr($request->server('HTTP_ACCEPT_LANGUAGE'), 0, 2);
+
+            if (in_array($locale, config('translation.locales'))) {
+                $request->cookies->set('locale', $locale);
+            }
+        } else {
+            $locale = $request->cookie('locale');
+        }
+
+        $this->setLocale($locale);
+
+        return $locale;
+    }
 }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -15,7 +15,7 @@ class FunctionalTestCase extends TestCase
         parent::setUp();
 
         $this->loadMigrationsFrom(__DIR__."/../src/Migrations");
-        
+
         $this->artisan('migrate');
     }
 

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -14,10 +14,9 @@ class FunctionalTestCase extends TestCase
     {
         parent::setUp();
 
-        $this->artisan('migrate', [
-            '--database' => 'testbench',
-            '--realpath' => realpath(__DIR__.'/../src/Migrations'),
-        ]);
+        $this->loadMigrationsFrom(__DIR__."/../src/Migrations");
+        
+        $this->artisan('migrate');
     }
 
     /**
@@ -61,5 +60,14 @@ class FunctionalTestCase extends TestCase
     protected function getPackageAliases($app)
     {
         return ['Translation' => \Stevebauman\Translation\Facades\Translation::class];
+    }
+
+    protected function loadMigrationsFrom($paths) {
+        $paths = (is_array($paths)) ? $paths : [$paths];
+        $this->app->afterResolving('migrator', function ($migrator) use ($paths) {
+            foreach ((array) $paths as $path) {
+                $migrator->path($path);
+            }
+        });
     }
 }

--- a/tests/GoogleTranslateApiTest.php
+++ b/tests/GoogleTranslateApiTest.php
@@ -108,13 +108,13 @@ class GoogleTranslateApiTest extends FunctionalTestCase
                 'q'      => $text,
             ],
         ])->andReturn($response);
-
+        
         $response->shouldReceive('getBody')->andReturn(json_encode([]));
 
         $this->client->setSource('en');
         $this->client->setTarget('es');
 
-        $this->setExpectedException(\ErrorException::class);
+        $this->expectException(\ErrorException::class);
         $this->client->translate($text);
     }
 
@@ -139,7 +139,7 @@ class GoogleTranslateApiTest extends FunctionalTestCase
         $this->client->setSource('en');
         $this->client->setTarget('es');
 
-        $this->setExpectedException(\ErrorException::class);
+        $this->expectException(\ErrorException::class);
         $this->client->translate($text);
     }
 }

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -9,6 +9,13 @@ use Stevebauman\Translation\Models\Translation as TranslationModel;
 
 class TranslationTest extends FunctionalTestCase
 {
+    public function testItCanDetectLocalesSetByBrowsers(){
+        request()->server->set('HTTP_ACCEPT_LANGUAGE','es-Spain');
+
+        $this->assertEquals("es",Translation::detectLocale(request()));
+        $this->assertEquals("Hola",Translation::translate("Hello"));
+    }
+
     public function testDefaultTranslationCanBeSet(){
         Translation::setLocale('fr');
 

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -24,7 +24,7 @@ class TranslationTest extends FunctionalTestCase
 
     public function testTranslationInvalidText()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Translation::translate(['Invalid']);
     }

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -9,6 +9,12 @@ use Stevebauman\Translation\Models\Translation as TranslationModel;
 
 class TranslationTest extends FunctionalTestCase
 {
+    public function testDefaultTranslationCanBeSet(){
+        Translation::setLocale('fr');
+
+        $this->assertEquals("Bonjour le monde", Translation::translate("Hello World"));
+    }
+
     public function testTranslationInvalidText()
     {
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
In this pull request, I've solved several issues reported by users of the package. 

- SetLocale now functions as expected. (The Locale Variable was being set from the method, but not used anywhere in the translate method.) 
- I have also rewrote the middleware to support automatic detection of the users language using the HTTP_ACCEPT_LANGUAGE sever variable. 
- I have made clearCacheTranslation public to allow for manual cache busting for users who want to build a manager on top of the package.