### PR TITLE
make dependencies Laravel 9.x compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/database": "^7.0|^6.0|^5.0",
-        "illuminate/support": "^7.0|^6.0|^5.0",
-        "stichoza/google-translate-php": "^4.1",
-        "guzzlehttp/guzzle": "~6.0"
+        "illuminate/database": "^8.0|^7.0|^6.0|^5.0",
+        "illuminate/support": "^8.0|^7.0|^6.0|^5.0",
+        "stichoza/google-translate-php": "^4.1.5",
+        "guzzlehttp/guzzle": ">=6.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.0",


### PR DESCRIPTION
update stichoza/google-translate-php from version 4.1 to 4.1.5 to better translation